### PR TITLE
Various dependency updates and Lombok functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,41 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Versions before 4.0.0 are available on [GitLab](https://gitlab.cc-asp.fraunhofer.de/fhg-isst-ids/ids-framework)
 
+## [5.0.5] - UNRELEASED
+
+### Changes:
+- Patch Change: Code refactoring to include more pre-built Lombok functionality
+
+### Dependency Maintenance
+- Upgrade: org.projectlombok:lombok 1.18.10 -> 1.18.20
+- Upgrade: org.slf4j:slf4j-api 1.7.28 -> 1.7.31
+- Upgrade: com.squareup.okhttp3:mockwebserver 4.2.2 -> 4.9.1
+- Upgrade: com.squareup.okhttp3:okhttp 4.2.2 -> 4.9.1
+- Upgrade: io.netty:netty-common 4.1.43.Final -> 4.1.65.Final
+- Upgrade: io.netty:netty-transport 4.1.43.Final -> 4.1.65.Final
+- Upgrade: mysql:mysql-connector-java 8.0.18 -> 8.0.25
+- Upgrade: org.apache.commons:commons-compress 1.19 -> 1.20
+- Upgrade: org.apache.commons:commons-csv 1.7 -> 1.8
+- Upgrade: org.apache.poi:poi-ooxml 4.1.1 -> 5.0.0
+- Upgrade: org.bitbucket.b_c:jose4j 0.7.0 -> 0.7.8
+- Upgrade: org.bouncycastle:bcpkix-fips 1.0.4 -> 1.0.5
+- Upgrade: org.eclipse.paho:org.eclipse.paho.client.mqttv3 1.2.2 -> 1.2.5
+- Upgrade: org.jooq:jooq 3.12.2 -> 3.14.11
+- Upgrade: org.json:json 20190722 -> 20210307
+- Upgrade: org.junit.jupiter:junit-jupiter-api 5.5.2 -> 5.7.2
+- Upgrade: org.junit.jupiter:junit-jupiter-engine 5.5.2 -> 5.7.2
+- Upgrade: org.mapstruct:mapstruct-processor 1.3.1.Final -> 1.4.2.Final
+- Upgrade: org.springframework.boot:spring-boot-starter 2.4.3 -> 2.5.1
+- Upgrade: org.springframework.boot:spring-boot-starter-test 2.4.3 -> 2.5.1
+- Upgrade: org.springframework:spring-test 5.3.4 -> 5.3.8
+- Upgrade: org.springframework:spring-tx 5.3.4 -> 5.3.8
+- Upgrade: org.springframework:spring-web 5.3.4 -> 5.3.8
+- Upgrade: org.springframework:spring-webmvc 5.3.4 -> 5.3.8
+- Upgrade: com.fasterxml.jackson.core:jackson-databind 2.10.1 -> 2.12.3
+- Upgrade: io.springfox:springfox-bean-validators 2.9.2 -> 3.0.0
+- Upgrade: io.springfox:springfox-swagger-ui 2.9.2 -> 3.0.0
+- Upgrade: io.springfox:springfox-swagger2 2.9.2 -> 3.0.0
+
 ## [5.0.4] - 2021-06-21
 
 ### Patch Change: Infomodel Maintenance

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>2.4.3</version>
+            <version>2.5.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.4.3</version>
+            <version>2.5.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -115,13 +115,6 @@
             <groupId>javax.persistence</groupId>
             <artifactId>javax.persistence-api</artifactId>
             <version>2.2</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -260,7 +253,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.19</version>
+            <version>1.20</version>
         </dependency>
 
         <dependency>
@@ -279,7 +272,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.5</version>
         </dependency>
 
     </dependencies>

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/broker/BrokerIDSMessageUtils.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/broker/BrokerIDSMessageUtils.java
@@ -20,6 +20,8 @@ import de.fraunhofer.iais.eis.ResourceUpdateMessage;
 import de.fraunhofer.iais.eis.ResourceUpdateMessageBuilder;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.ids.framework.util.IDSUtils;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.experimental.UtilityClass;
 import okhttp3.MultipartBody;
 
@@ -27,9 +29,10 @@ import okhttp3.MultipartBody;
  * The MessageUtils class contains utility methods for building Infomodel Messages (used by the {@link IDSBrokerServiceImpl} class).
  */
 @UtilityClass
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class BrokerIDSMessageUtils {
 
-    private static final Serializer SERIALIZER = new Serializer();
+    static Serializer SERIALIZER = new Serializer();
 
     /**
      * Create a ResourceUnavailableMessage used for unregistering the given resource at a broker.

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/broker/IDSBrokerServiceImpl.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/broker/IDSBrokerServiceImpl.java
@@ -13,6 +13,9 @@ import de.fraunhofer.isst.ids.framework.configuration.ConfigurationContainer;
 import de.fraunhofer.isst.ids.framework.daps.DapsTokenProvider;
 import de.fraunhofer.isst.ids.framework.util.ClientProvider;
 import de.fraunhofer.isst.ids.framework.util.IDSUtils;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -28,29 +31,16 @@ import org.springframework.stereotype.Service;
  **/
 @Slf4j
 @Service
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class IDSBrokerServiceImpl implements IDSBrokerService {
 
-    private static final String     INFO_MODEL_VERSION = "4.0.0";
-    private static final Serializer SERIALIZER         = new Serializer();
+    static final String     INFO_MODEL_VERSION = "4.0.0";
+    static final Serializer SERIALIZER         = new Serializer();
 
-    private ConfigurationContainer container;
-    private ClientProvider clientProvider;
-    private DapsTokenProvider tokenProvider;
-
-    /**
-     * Creates the IDSBrokerCommunication controller.
-     *
-     * @param container Configuration container
-     * @param provider providing underlying OkHttpClient
-     * @param tokenProvider providing DAT Token for RequestMessage
-     */
-    public IDSBrokerServiceImpl(final ConfigurationContainer container,
-                                final ClientProvider provider,
-                                final DapsTokenProvider tokenProvider) {
-        this.container = container;
-        this.clientProvider = provider;
-        this.tokenProvider = tokenProvider;
-    }
+    ConfigurationContainer container;
+    ClientProvider clientProvider;
+    DapsTokenProvider tokenProvider;
 
     /** {@inheritDoc} */
     @Override

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/http/HttpServiceImpl.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/http/HttpServiceImpl.java
@@ -7,8 +7,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import de.fraunhofer.isst.ids.framework.util.ClientProvider;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -23,10 +25,11 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class HttpServiceImpl implements HttpService {
 
-    private ClientProvider provider;
-    private TimeoutSettings timeoutSettings;
+    ClientProvider provider;
+    TimeoutSettings timeoutSettings;
 
     /**
      * @param provider the {@link ClientProvider} used to generate HttpClients with the current connector configuration

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/http/IDSHttpServiceImpl.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/http/IDSHttpServiceImpl.java
@@ -9,6 +9,9 @@ import de.fraunhofer.isst.ids.framework.configuration.ConfigurationContainer;
 import de.fraunhofer.isst.ids.framework.daps.ClaimsException;
 import de.fraunhofer.isst.ids.framework.daps.DapsValidator;
 import de.fraunhofer.isst.ids.framework.util.MultipartStringParser;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -20,19 +23,13 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class IDSHttpServiceImpl implements IDSHttpService {
 
-    private HttpService httpService;
-    private DapsValidator dapsValidator;
-    private ConfigurationContainer configurationContainer;
-
-    public IDSHttpServiceImpl(final HttpService httpService,
-                              final DapsValidator dapsValidator,
-                              final ConfigurationContainer configurationContainer) {
-        this.httpService = httpService;
-        this.dapsValidator = dapsValidator;
-        this.configurationContainer = configurationContainer;
-    }
+    HttpService httpService;
+    DapsValidator dapsValidator;
+    ConfigurationContainer configurationContainer;
 
     /** {@inheritDoc} */
     @Override

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/http/InfomodelMessageBuilder.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/http/InfomodelMessageBuilder.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
@@ -13,11 +15,12 @@ import okhttp3.RequestBody;
  * This Builder is a utility class for building OkHTTP
  * Multipart RequestBodies with RequestMessage header and String or File payload Part.
  */
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class InfomodelMessageBuilder {
 
-    private MultipartBody.Builder builder;
+    MultipartBody.Builder builder;
 
-    private static final Serializer SERIALIZER = new Serializer();
+    static final Serializer SERIALIZER = new Serializer();
 
     /**
      * Internal builder used by the static methods.

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/mqtt/IDSMQTTCommunication.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/mqtt/IDSMQTTCommunication.java
@@ -4,8 +4,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.Queue;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
 import org.eclipse.paho.client.mqttv3.MqttClient;
@@ -17,15 +19,16 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
  * This class implements IDSCommunication for the MQTT Protocol.
  */
 @Slf4j
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class IDSMQTTCommunication {
 
-    private Queue<String> messageQueue;
+    Queue<String> messageQueue;
 
     @Getter @Setter
-    private MqttClient client = null;
+    MqttClient client = null;
 
     @Getter
-    private final MqttConnectOptions opt;
+    final MqttConnectOptions opt;
 
     public IDSMQTTCommunication() {
         super();

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/mqtt/ProtocolMqtt.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/communication/mqtt/ProtocolMqtt.java
@@ -4,19 +4,22 @@ import java.net.URI;
 import java.util.Properties;
 
 import de.fraunhofer.iais.eis.BasicAuthentication;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.experimental.FieldDefaults;
 
 /**
  * Utility class for handling Mqtt Connections.
  */
 @Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class ProtocolMqtt {
-    private BasicAuthentication basicAuthentication;
-    private int qos;
-    private URI uri;
-    private String clientId;
-    private String topic;
-    private String lastWillTopic;
-    private String lastWillMessage;
-    private Properties sslProperties;
+    BasicAuthentication basicAuthentication;
+    int qos;
+    URI uri;
+    String clientId;
+    String topic;
+    String lastWillTopic;
+    String lastWillMessage;
+    Properties sslProperties;
 }

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/ConfigProducer.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/ConfigProducer.java
@@ -11,6 +11,8 @@ import de.fraunhofer.iais.eis.ConfigurationModel;
 import de.fraunhofer.iais.eis.Connector;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.ids.framework.util.ClientProvider;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -26,14 +28,15 @@ import org.springframework.core.io.ClassPathResource;
  */
 @Slf4j
 @Configuration
+@FieldDefaults(level = AccessLevel.PRIVATE)
 @EnableConfigurationProperties(ConfigProperties.class)
 @ConditionalOnClass({ConfigurationModel.class, Connector.class, KeyStoreManager.class})
 public class ConfigProducer {
 
-    private static final Serializer SERIALIZER = new Serializer();
+    static final Serializer SERIALIZER = new Serializer();
 
-    private ConfigurationContainer configurationContainer;
-    private ClientProvider clientProvider;
+    ConfigurationContainer configurationContainer;
+    ClientProvider clientProvider;
 
     /**
      * Load the ConfigurationModel from the location specified in the application.properties, initialize the KeyStoreManager.

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/ConfigProperties.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/ConfigProperties.java
@@ -1,6 +1,8 @@
 package de.fraunhofer.isst.ids.framework.configuration;
 
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.experimental.FieldDefaults;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -8,23 +10,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Properties should be added to the application.properties file
  */
 @Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
 @ConfigurationProperties(prefix = "configuration")
 public class ConfigProperties {
 
     /**
      * Path to a configuration File (JsonLD representation of a {@link de.fraunhofer.iais.eis.ConfigurationModel}.
      */
-    private String path;
+    String path;
     /**
      * Password for the IDSKeystore configured in the {@link de.fraunhofer.iais.eis.ConfigurationModel} keyStore field.
      */
-    private String keyStorePassword;
+    String keyStorePassword;
     /**
      * Alias of the connectors private key (used for signing DAT Requests).
      */
-    private String keyAlias;
+    String keyAlias;
     /**
      * Password for the IDSTruststore configured in the {@link de.fraunhofer.iais.eis.ConfigurationModel} trustStore field.
      */
-    private String trustStorePassword;
+    String trustStorePassword;
 }

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/ConfigurationContainer.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/ConfigurationContainer.java
@@ -6,6 +6,8 @@ import java.security.NoSuchAlgorithmException;
 import de.fraunhofer.iais.eis.ConfigurationModel;
 import de.fraunhofer.iais.eis.Connector;
 import de.fraunhofer.isst.ids.framework.util.ClientProvider;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -13,11 +15,12 @@ import lombok.extern.slf4j.Slf4j;
  * and manages changes of the configuration.
  */
 @Slf4j
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class ConfigurationContainer {
 
-    private ConfigurationModel configurationModel;
-    private KeyStoreManager keyStoreManager;
-    private ClientProvider clientProvider;
+    ConfigurationModel configurationModel;
+    KeyStoreManager keyStoreManager;
+    ClientProvider clientProvider;
 
     /**
      * Create a ConfigurationContainer with a ConfigurationModel and KeyStoreManager.

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/KeyStoreManager.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/configuration/KeyStoreManager.java
@@ -5,7 +5,6 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.security.KeyStore;
@@ -22,7 +21,9 @@ import java.util.stream.IntStream;
 
 import de.fraunhofer.iais.eis.ConfigurationModel;
 import de.fraunhofer.isst.ids.framework.util.IDSUtils;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 
@@ -38,17 +39,18 @@ import org.springframework.core.io.ClassPathResource;
  */
 @Slf4j
 @Getter
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class KeyStoreManager {
 
-    private ConfigurationModel configurationModel;
-    private KeyStore keyStore;
-    private char[] keyStorePw;
-    private String keyAlias;
-    private KeyStore trustStore;
-    private char[] trustStorePw;
-    private PrivateKey privateKey;
-    private Certificate cert;
-    private X509TrustManager trustManager;
+    ConfigurationModel configurationModel;
+    KeyStore keyStore;
+    char[] keyStorePw;
+    String keyAlias;
+    KeyStore trustStore;
+    char[] trustStorePw;
+    PrivateKey privateKey;
+    Certificate cert;
+    X509TrustManager trustManager;
 
     /**
      * Build the KeyStoreManager from the given configuration.
@@ -206,7 +208,7 @@ public class KeyStoreManager {
      * @throws UnrecoverableKeyException if the key cannot be recovered (e.g. the given password is wrong)
      * @throws KeyStoreException if initialization of the trustmanager fails
      */
-    private X509TrustManager loadTrustManager(final char[] password)
+    private X509TrustManager loadTrustManager(final char... password)
             throws NoSuchAlgorithmException, KeyStoreException, UnrecoverableKeyException {
         if (log.isDebugEnabled()) {
             log.debug("Loading trustmanager");

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/daps/DapsValidator.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/daps/DapsValidator.java
@@ -11,6 +11,8 @@ import de.fraunhofer.isst.ids.framework.util.MultipartStringParser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.fileupload.FileUploadException;
 import org.springframework.stereotype.Service;
@@ -20,10 +22,11 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class DapsValidator {
 
-    private DapsPublicKeyProvider keyProvider;
-    private Serializer serializer = new Serializer();
+    DapsPublicKeyProvider keyProvider;
+    Serializer serializer = new Serializer();
 
     public DapsValidator(final DapsPublicKeyProvider keyProvider) {
         this.keyProvider = keyProvider;

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/daps/TokenProvider.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/daps/TokenProvider.java
@@ -9,6 +9,8 @@ import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
 import de.fraunhofer.iais.eis.TokenFormat;
 import de.fraunhofer.isst.ids.framework.configuration.ConfigurationContainer;
 import de.fraunhofer.isst.ids.framework.util.ClientProvider;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Request;
 import org.jose4j.jwk.JsonWebKeySet;
@@ -23,20 +25,21 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class TokenProvider implements DapsTokenProvider, DapsPublicKeyProvider {
 
-    private ConfigurationContainer configurationContainer;
-    private ClientProvider clientProvider;
-    private Key publicKey;
+    ConfigurationContainer configurationContainer;
+    ClientProvider clientProvider;
+    Key publicKey;
 
     @Value("${daps.key.url}")
-    private String dapsKeyUrl;
+    String dapsKeyUrl;
 
     @Value("${daps.token.url}")
-    private String dapsUrl;
+    String dapsUrl;
 
     @Value("${daps.kid.url:default}")
-    private String keyKid;
+    String keyKid;
 
     /**
      *

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/util/ClientProvider.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/util/ClientProvider.java
@@ -17,6 +17,8 @@ import java.util.List;
 import de.fraunhofer.iais.eis.ConfigurationModel;
 import de.fraunhofer.isst.ids.framework.configuration.ConfigurationContainer;
 import de.fraunhofer.isst.ids.framework.configuration.KeyStoreManager;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Authenticator;
 import okhttp3.Credentials;
@@ -26,10 +28,11 @@ import okhttp3.OkHttpClient;
  * The ClientProvider uses the {@link ConfigurationContainer} to rebuild clients, when a new configurationContainer is created.
  */
 @Slf4j
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class ClientProvider {
 
-    private ConfigurationContainer configContainer;
-    private OkHttpClient client;
+    ConfigurationContainer configContainer;
+    OkHttpClient client;
 
     /**
      * Constructor, creating a Client provider using the KeyStore part from the ConfigurationContainer.

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/util/IDSUtils.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/util/IDSUtils.java
@@ -20,6 +20,8 @@ import java.util.Properties;
 import de.fraunhofer.iais.eis.ConfigurationModel;
 import de.fraunhofer.iais.eis.Connector;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
@@ -29,10 +31,11 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @UtilityClass
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class IDSUtils {
 
-    private static final Base64.Encoder ENCODER    = Base64.getEncoder();
-    private static final Serializer     SERIALIZER = new Serializer();
+    static Base64.Encoder ENCODER    = Base64.getEncoder();
+    static Serializer     SERIALIZER = new Serializer();
 
     /**
      * Hash a value with a given MessageDigest.

--- a/base/src/main/java/de/fraunhofer/isst/ids/framework/util/MultipartStringParser.java
+++ b/base/src/main/java/de/fraunhofer/isst/ids/framework/util/MultipartStringParser.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileUpload;
 import org.apache.commons.fileupload.FileUploadException;
@@ -15,11 +17,12 @@ import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 /**
  * Utility Class for parsing Multipart Maps from String responses.
  */
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class MultipartStringParser implements UploadContext {
 
-    private String postBody;
-    private String boundary;
-    private Map<String, String> parameters = new ConcurrentHashMap<>();
+    String postBody;
+    String boundary;
+    Map<String, String> parameters = new ConcurrentHashMap<>();
 
     /**
      * Constructor for the MultipartStringParser used internally to parse a multipart response to a Map<Partname, MessagePart>.

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -22,11 +22,11 @@
     </licenses>
 
     <properties>
-        <springfox-swagger.version>2.9.2</springfox-swagger.version>
+        <springfox-swagger.version>3.0.0</springfox-swagger.version>
         <sonar.projectKey>de.fraunhofer.isst.ids.framework.messaging.core</sonar.projectKey>
         <spring-boot-starter-web.version>2.2.0.RELEASE</spring-boot-starter-web.version>
-        <spring-tx.version>5.3.4</spring-tx.version>
-        <spring-web.version>5.3.4</spring-web.version>
+        <spring-tx.version>5.3.8</spring-tx.version>
+        <spring-web.version>5.3.8</spring-web.version>
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
     </properties>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
-            <version>5.3.4</version>
+            <version>5.3.8</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.springframework/spring-tx -->
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
-            <version>5.3.4</version>
+            <version>5.3.8</version>
             <scope>test</scope>
         </dependency>
 

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/IDSController.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/IDSController.java
@@ -18,6 +18,8 @@ import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.ids.framework.configuration.ConfigurationContainer;
 import de.fraunhofer.isst.ids.framework.messaging.model.filters.PreProcessingException;
 import de.fraunhofer.isst.ids.framework.util.IDSUtils;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -32,14 +34,15 @@ import org.springframework.util.MultiValueMap;
  */
 @Slf4j
 @Controller
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class IDSController {
 
-    private static final String HEADER_MULTIPART_NAME = "header";
-    private static final String PAYLOAD_MULTIPART_NAME = "payload";
+    static String HEADER_MULTIPART_NAME = "header";
+    static String PAYLOAD_MULTIPART_NAME = "payload";
 
-    private final MessageDispatcher messageDispatcher;
-    private final ConfigurationContainer configurationContainer;
-    private final Serializer serializer;
+    MessageDispatcher messageDispatcher;
+    ConfigurationContainer configurationContainer;
+    Serializer serializer;
 
     @Autowired
     public IDSController(final MessageDispatcher messageDispatcher,

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/IDSEndpointService.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/IDSEndpointService.java
@@ -2,6 +2,8 @@ package de.fraunhofer.isst.ids.framework.messaging.handling;
 
 import javax.servlet.http.HttpServletRequest;
 
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -15,10 +17,11 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  */
 @Slf4j
 @Service
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class IDSEndpointService {
 
-    private IDSController idsController;
-    private RequestMappingHandlerMapping requestMappingHandlerMapping;
+    IDSController idsController;
+    RequestMappingHandlerMapping requestMappingHandlerMapping;
 
     /**
      * Use <code>/api/ids/data</code> and <code>/api/ids/infrastructure</code> routes as default mappings.

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/MessageDispatcher.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/MessageDispatcher.java
@@ -21,6 +21,8 @@ import de.fraunhofer.isst.ids.framework.messaging.model.messages.MessageHandling
 import de.fraunhofer.isst.ids.framework.messaging.model.messages.MessagePayloadImpl;
 import de.fraunhofer.isst.ids.framework.messaging.model.responses.ErrorResponse;
 import de.fraunhofer.isst.ids.framework.messaging.model.responses.MessageResponse;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -29,12 +31,13 @@ import lombok.extern.slf4j.Slf4j;
  * the results returned by the MessageHandlers.
  */
 @Slf4j
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class MessageDispatcher {
 
-    private final ObjectMapper objectMapper;
-    private final List<PreDispatchingFilter> preDispatchingFilters;
-    private final RequestHandlerResolver requestHandlerResolver;
-    private final ConfigurationContainer configurationContainer;
+    ObjectMapper objectMapper;
+    List<PreDispatchingFilter> preDispatchingFilters;
+    RequestHandlerResolver requestHandlerResolver;
+    ConfigurationContainer configurationContainer;
 
     /**
      * Create a MessageDispatcher.

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/SpringRequestHandlerResolver.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/handling/SpringRequestHandlerResolver.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
  * Resolver that uses the Spring dependency injection mechanism to find the matching message handler.
  */
 @Service
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class SpringRequestHandlerResolver implements RequestHandlerResolver {
 
     private final ApplicationContext appContext;
@@ -25,16 +26,6 @@ public class SpringRequestHandlerResolver implements RequestHandlerResolver {
     private static class Tuple<K, V> {
         final K key;
         final V value;
-    }
-
-    /**
-     * Default constructor autowired by Spring and sets ApplicationContext from Spring.
-     *
-     * @param appContext context to access Spring CDI
-     */
-    @Autowired
-    public SpringRequestHandlerResolver(final ApplicationContext appContext) {
-        this.appContext = appContext;
     }
 
     /**

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/filters/PreDispatchingFilterResult.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/filters/PreDispatchingFilterResult.java
@@ -2,27 +2,20 @@ package de.fraunhofer.isst.ids.framework.messaging.model.filters;
 
 import java.util.Objects;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
 /**
  * Result that is returned by a PreDispatchingFilter (with information about why a message was accepted or rejected).
  */
+@RequiredArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class PreDispatchingFilterResult {
 
-    private final Throwable error;
-    private final boolean success;
-    private final String message;
-
-    /**
-     * The result contains a message about its result, can contain an error if something went wrong and has a boolean flag for success.
-     *
-     * @param error an error that occured during PreDispatchingFilter processing
-     * @param success true if the predispatchingfilter successfully checked and accepted the message
-     * @param message information about why the {@link PreDispatchingFilter} accepted (or rejected) the message.
-     */
-    protected PreDispatchingFilterResult(final Throwable error, final boolean success, final String message) {
-        this.error = error;
-        this.success = success;
-        this.message = message;
-    }
+    Throwable error;
+    boolean success;
+    String message;
 
     /**
      * Static method returning a builder.

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/messages/MessagePayloadImpl.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/messages/MessagePayloadImpl.java
@@ -4,19 +4,19 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.experimental.FieldDefaults;
 
 /**
  * Implementation of {@link MessagePayload} interface. Can parse payload from JSON and return the resulting inputstream.
  */
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class MessagePayloadImpl implements MessagePayload {
 
-    private final InputStream underlyingInputStream;
-    private final ObjectMapper objectMapper;
-
-    public MessagePayloadImpl(final InputStream underlyingInputStream, final ObjectMapper objectMapper) {
-        this.underlyingInputStream = underlyingInputStream;
-        this.objectMapper = objectMapper;
-    }
+    InputStream underlyingInputStream;
+    ObjectMapper objectMapper;
 
     @Override
     public InputStream getUnderlyingInputStream() {

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/Base64EncodedFileBodyResponse.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/Base64EncodedFileBodyResponse.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.RequestMessage;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
+import lombok.experimental.FieldDefaults;
 import org.apache.commons.io.FileUtils;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -18,10 +19,11 @@ import org.springframework.http.MediaType;
  * Utility class for returning files using Base64 encoding.
  * @param <T> a subclass of ResponseMessage or NotificationMessage
  */
+@FieldDefaults(makeFinal = true)
 public class Base64EncodedFileBodyResponse<T extends Message> implements MessageResponse {
 
-    final T header;
-    final HttpEntity<byte[]> payload;
+    T header;
+    HttpEntity<byte[]> payload;
 
     /**
      * Create a MessageResponse with a Payload containing a Base64 encoded File.

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/BodyResponse.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/BodyResponse.java
@@ -8,6 +8,7 @@ import de.fraunhofer.iais.eis.Message;
 import de.fraunhofer.iais.eis.RequestMessage;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import lombok.Data;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -15,10 +16,11 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Data
 @Slf4j
+@FieldDefaults(makeFinal = true)
 public class BodyResponse<T extends Message> implements MessageResponse {
 
-    final T header;
-    final Object payload;
+    T header;
+    Object payload;
 
     /**
      * @param header ResponseMessage or NotificationMessage for the header

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/ErrorResponse.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/model/responses/ErrorResponse.java
@@ -12,7 +12,10 @@ import de.fraunhofer.iais.eis.RejectionReason;
 import de.fraunhofer.iais.eis.TokenFormat;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.ids.framework.util.IDSUtils;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -20,21 +23,12 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Data
 @Slf4j
+@AllArgsConstructor
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class ErrorResponse implements MessageResponse {
 
-    private final RejectionMessage rejectionMessage;
-    private final String errorMessage;
-
-    /**
-     * Create an ErrorResponse with a RejectionMessage header and errorReason String payload.
-     *
-     * @param rejectionMessage a RejectionMessage
-     * @param errorMessage a detailed Error description
-     */
-    public ErrorResponse(final RejectionMessage rejectionMessage, final String errorMessage) {
-        this.rejectionMessage = rejectionMessage;
-        this.errorMessage = errorMessage;
-    }
+    RejectionMessage rejectionMessage;
+    String errorMessage;
 
     /**
      * Create an ErrorResponse with a RejectionMessage header and errorReason String payload.

--- a/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/util/ResourceIDGenerator.java
+++ b/messaging/src/main/java/de/fraunhofer/isst/ids/framework/messaging/util/ResourceIDGenerator.java
@@ -4,14 +4,18 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.UtilityClass;
+
 /**
  * Utility for generating Resource IDs for infomodel builders.
  */
+@UtilityClass
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public final class ResourceIDGenerator {
 
-    private static final String AUTOGEN = "https://w3id.org/idsa/autogen";
-
-    private ResourceIDGenerator() { }
+    static String AUTOGEN = "https://w3id.org/idsa/autogen";
 
     /**
      * Create an URI with callerClazz name and random uuid in path (used as ID URIs).

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </modules>
 
     <properties>
-        <revision>5.0.4</revision>
+        <revision>5.0.5</revision>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -55,7 +55,7 @@
         <dependency-check-maven.version>5.2.2</dependency-check-maven.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <flatten-maven-plugin.version>1.1.0</flatten-maven-plugin.version>
-        <jose4j.version>0.7.0</jose4j.version>
+        <jose4j.version>0.7.8</jose4j.version>
 
         <!-- internal dependencies -->
 <!--    <yaim.version>0.1.1-SNAPSHOT</yaim.version>-->
@@ -65,31 +65,31 @@
 
         <!-- production dependencies -->
         <servlet-api.version>4.0.1</servlet-api.version>
-        <mqttv3.version>1.2.2</mqttv3.version>
-        <poi-ooxml.version>4.1.1</poi-ooxml.version>
+        <mqttv3.version>1.2.5</mqttv3.version>
+        <poi-ooxml.version>5.0.0</poi-ooxml.version>
         <commons-fileupload.version>1.4</commons-fileupload.version>
-        <commons-csv.version>1.7</commons-csv.version>
+        <commons-csv.version>1.8</commons-csv.version>
         <jjwt.version>0.9.1</jjwt.version>
-        <org-json.version>20190722</org-json.version>
-        <lombok.version>1.18.10</lombok.version>
-        <slf4j-api.version>1.7.28</slf4j-api.version>
-        <okhttp.version>4.2.2</okhttp.version>
-        <mysql-connector.version>8.0.18</mysql-connector.version>
+        <org-json.version>20210307</org-json.version>
+        <lombok.version>1.18.20</lombok.version>
+        <slf4j-api.version>1.7.31</slf4j-api.version>
+        <okhttp.version>4.9.1</okhttp.version>
+        <mysql-connector.version>8.0.25</mysql-connector.version>
         <h2.version>1.4.200</h2.version>
-        <jooq.version>3.12.2</jooq.version>
+        <jooq.version>3.14.11</jooq.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <javax.activation-api.version>1.2.0</javax.activation-api.version>
-        <jackson.databind.version>2.10.1</jackson.databind.version>
+        <jackson.databind.version>2.12.3</jackson.databind.version>
 
         <!-- Test dependencies -->
         <mariaDB4j.version>2.4.0</mariaDB4j.version>
-        <mockito.version>3.1.0</mockito.version>
-        <junit-jupiter.version>5.5.2</junit-jupiter.version>
+        <mockito.version>3.11.2</mockito.version>
+        <junit-jupiter.version>5.7.2</junit-jupiter.version>
         <moquette-broker.version>0.12.1</moquette-broker.version>
         <okhttp-mock.version>1.3.2</okhttp-mock.version>
         <okhttp3.mockwebserver.version>4.2.2</okhttp3.mockwebserver.version>
-        <netty-components.version>4.1.43.Final</netty-components.version>
-        <mapstruct.version>1.3.1.Final</mapstruct.version>
+        <netty-components.version>4.1.65.Final</netty-components.version>
+        <mapstruct.version>1.4.2.Final</mapstruct.version>
 
         <!-- Sonar Properties -->
         <sonar.projectName>IDS-Framework</sonar.projectName>
@@ -239,14 +239,6 @@
     </profiles>
 
     <dependencies>
-
-        <!-- IAIS Infomodel-->
-        <dependency>
-            <groupId>de.fraunhofer.iais.eis.ids.infomodel</groupId>
-            <artifactId>java</artifactId>
-            <version>${de.fraunhofer.iais.eis.ids.infomodel.version}</version>
-        </dependency>
-
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -345,6 +337,31 @@
                                             </limit>
                                         </limits>
                                     </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-maven</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireMavenVersion>
+                                        <version>3.2.5</version>
+                                    </requireMavenVersion>
                                 </rules>
                             </configuration>
                         </execution>


### PR DESCRIPTION
### Changes:
- Patch Change: Code refactoring to include more pre-built Lombok functionality

### Dependency Maintenance
- Upgrade: org.projectlombok:lombok 1.18.10 -> 1.18.20
- Upgrade: org.slf4j:slf4j-api 1.7.28 -> 1.7.31
- Upgrade: com.squareup.okhttp3:mockwebserver 4.2.2 -> 4.9.1
- Upgrade: com.squareup.okhttp3:okhttp 4.2.2 -> 4.9.1
- Upgrade: io.netty:netty-common 4.1.43.Final -> 4.1.65.Final
- Upgrade: io.netty:netty-transport 4.1.43.Final -> 4.1.65.Final
- Upgrade: mysql:mysql-connector-java 8.0.18 -> 8.0.25
- Upgrade: org.apache.commons:commons-compress 1.19 -> 1.20
- Upgrade: org.apache.commons:commons-csv 1.7 -> 1.8
- Upgrade: org.apache.poi:poi-ooxml 4.1.1 -> 5.0.0
- Upgrade: org.bitbucket.b_c:jose4j 0.7.0 -> 0.7.8
- Upgrade: org.bouncycastle:bcpkix-fips 1.0.4 -> 1.0.5
- Upgrade: org.eclipse.paho:org.eclipse.paho.client.mqttv3 1.2.2 -> 1.2.5
- Upgrade: org.jooq:jooq 3.12.2 -> 3.14.11
- Upgrade: org.json:json 20190722 -> 20210307
- Upgrade: org.junit.jupiter:junit-jupiter-api 5.5.2 -> 5.7.2
- Upgrade: org.junit.jupiter:junit-jupiter-engine 5.5.2 -> 5.7.2
- Upgrade: org.mapstruct:mapstruct-processor 1.3.1.Final -> 1.4.2.Final
- Upgrade: org.springframework.boot:spring-boot-starter 2.4.3 -> 2.5.1
- Upgrade: org.springframework.boot:spring-boot-starter-test 2.4.3 -> 2.5.1
- Upgrade: org.springframework:spring-test 5.3.4 -> 5.3.8
- Upgrade: org.springframework:spring-tx 5.3.4 -> 5.3.8
- Upgrade: org.springframework:spring-web 5.3.4 -> 5.3.8
- Upgrade: org.springframework:spring-webmvc 5.3.4 -> 5.3.8
- Upgrade: com.fasterxml.jackson.core:jackson-databind 2.10.1 -> 2.12.3
- Upgrade: io.springfox:springfox-bean-validators 2.9.2 -> 3.0.0
- Upgrade: io.springfox:springfox-swagger-ui 2.9.2 -> 3.0.0
- Upgrade: io.springfox:springfox-swagger2 2.9.2 -> 3.0.0